### PR TITLE
Porsche multi‑model support: generations + options MSRP + FE catalog; Taycan Active Ride

### DIFF
--- a/x987-app/CATALOG_EXPORT_README.md
+++ b/x987-app/CATALOG_EXPORT_README.md
@@ -1,0 +1,31 @@
+Generation Catalog Export (for FE docs)
+
+Purpose
+- Provide a single source of truth for FE to display trims and options per generation.
+
+Source of Truth
+- Python config: `x987-config/config.toml`
+  - `[vehicles.models.*.generations]` → trims per generation
+  - `[options_per_generation.<Model>.<Gen>.msrp]` → per-generation option IDs (used to list options)
+
+Exporter
+- Python module: `x987-app/x987/catalog/export.py`
+- Builds JSON with models → generations → { trims, options, default flags }
+
+Usage
+1) From `x987-app` directory:
+
+   python -m x987.catalog.export
+
+2) Output (default path):
+
+   x987-web/apps/api/data/generation_catalog.json
+
+API
+- The FE calls `GET /api/catalog/generations` which serves the JSON if present.
+- If not present, the API responds with `{ ok: true, source: 'defaults' }` and the FE shows a small “defaults pending” note.
+
+Notes
+- Options list per generation is populated only when `options_per_generation` has MSRP entries for that (model, gen). Otherwise FE indicates defaults are used.
+- Trims are always sourced from config and marked non-default.
+

--- a/x987-app/VEHICLE_CATALOG_README.md
+++ b/x987-app/VEHICLE_CATALOG_README.md
@@ -1,0 +1,21 @@
+Vehicle Catalog (Models/Trims)
+
+Purpose
+- Centralize model/trim detection in a config-driven, generation-aware catalog for scalability.
+
+Where
+- Config: `x987-config/config.toml` under `[vehicles]`.
+- Code: `x987-app/x987/vehicles.py` loads the catalog and exposes `detect_model_and_trim(text)`.
+- Extractors: `x987-app/x987/utils/extractors.py::extract_vehicle_info_unified` uses it.
+
+How to add models/trims
+- Add a new block under `[vehicles.models.<ModelKey>]` with:
+  - `name`: canonical model name (e.g., "911").
+  - `synonyms`: list of strings to recognize the model in text.
+  - `[[...generations]]`: each has `code`, `years = { min, max? }`, and nested `[[...generations.trims]]` with `name` and `synonyms`.
+  - Optionally, a top-level `[[...trims]]` array as a generic fallback across generations.
+
+Notes
+- Year-aware: when a year is present, only trims under the matching generation are considered first.
+- Trim matching prefers more specific synonyms first (e.g., "Carrera 4S" before "Carrera").
+- Complete coverage added per your list: Boxster/Cayman, 911, Cayenne, Panamera, Macan, Taycan.

--- a/x987-app/x987/catalog/export.py
+++ b/x987-app/x987/catalog/export.py
@@ -1,0 +1,95 @@
+"""
+Generation Catalog Exporter
+
+Builds a JSON catalog of models → generations → trims and options for FE/docs.
+Options are sourced from per-generation MSRP overrides if available; otherwise options list is omitted and marked as defaults in the JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from x987.config.manager import get_config
+from x987.vehicles import get_vehicle_catalog
+from x987.options.registry import OptionsRegistry
+
+
+def build_generation_catalog() -> Dict[str, Any]:
+    cfg = get_config()
+    vehicles = get_vehicle_catalog()
+    # Build option id → display mapping from registry
+    reg = OptionsRegistry()
+    id_to_display: Dict[str, str] = {}
+    for opt in reg.get_all_options():
+        try:
+            oid = getattr(opt, 'get_id')()
+            disp = getattr(opt, 'get_display')()
+            if oid:
+                id_to_display[str(oid)] = disp
+        except Exception:
+            continue
+
+    opg = cfg.get('options_per_generation', {}) or {}
+
+    models_out: List[Dict[str, Any]] = []
+    for m in vehicles:
+        model_entry: Dict[str, Any] = {
+            'name': m.name,
+            'generations': []
+        }
+        # Model-level trims are not used; we list per-generation
+        for g in m.generations:
+            key = f"{m.name}-{g.code}"
+            trims = [t.name for t in g.trims]
+            # Options from per-generation MSRP map, if present
+            gen_opts: List[Dict[str, Any]] = []
+            options_default = True
+            try:
+                model_map = opg.get(m.name, {}) or {}
+                gen_map = model_map.get(g.code, {}) or {}
+                msrp_map = gen_map.get('msrp', {}) or {}
+                if msrp_map:
+                    for oid, msrp in msrp_map.items():
+                        disp = id_to_display.get(str(oid), str(oid))
+                        try:
+                            msrp_int = int(msrp)
+                        except Exception:
+                            msrp_int = None
+                        gen_opts.append({
+                            'id': str(oid),
+                            'display': disp,
+                            'msrp': msrp_int
+                        })
+                    options_default = False
+            except Exception:
+                pass
+
+            model_entry['generations'].append({
+                'key': key,
+                'code': g.code,
+                'years': {'min': g.min_year, 'max': g.max_year},
+                'trims': trims,
+                'trims_default': False,  # trims come from config; considered authoritative
+                'options': gen_opts,
+                'options_default': options_default
+            })
+        models_out.append(model_entry)
+
+    return {'models': models_out}
+
+
+def export_generation_catalog_json(out_path: Path) -> Path:
+    data = build_generation_catalog()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+    return out_path
+
+
+if __name__ == '__main__':
+    # Default output path co-located with FE API for easy serving
+    default_out = Path.cwd().parent / 'x987-web' / 'apps' / 'api' / 'data' / 'generation_catalog.json'
+    p = export_generation_catalog_json(default_out)
+    print(f"✓ Exported generation catalog to {p}")

--- a/x987-app/x987/options/active_ride.py
+++ b/x987-app/x987/options/active_ride.py
@@ -1,0 +1,56 @@
+"""
+Porsche Active Ride (Adaptive Suspension) Option
+
+Detects Taycan's generation-specific Porsche Active Ride system.
+"""
+
+import re
+from typing import List
+
+
+class ActiveRideOption:
+    def __init__(self):
+        self.id = "ACTIVE_RIDE"
+        self.display = "Porsche Active Ride (Adaptive Suspension)"
+        self.value_usd = 0  # Spec value accounted for via MSRP overrides/fallback catalog
+        self.category = "performance"
+        self.patterns = [
+            r"\bporsche\s+active\s+ride\b",
+            r"\bactive\s+ride\b",
+            r"\bactive\s+ride\s+adaptive\s+suspension\b",
+            r"\badaptive\s+suspension\b"  # keep broad for coverage; PASM has own file
+        ]
+        self.compiled_patterns = self._compile_patterns()
+
+    def _compile_patterns(self) -> List[re.Pattern]:
+        out: List[re.Pattern] = []
+        for p in self.patterns:
+            try:
+                out.append(re.compile(p, re.IGNORECASE))
+            except re.error:
+                pass
+        return out
+
+    def is_present(self, text: str, trim: str = None) -> bool:
+        if not text:
+            return False
+        for pat in self.compiled_patterns:
+            if pat.search(text):
+                return True
+        return False
+
+    def get_value(self, text: str, trim: str = None) -> int:
+        return self.value_usd if self.is_present(text, trim) else 0
+
+    def get_display(self) -> str:
+        return self.display
+
+    def get_category(self) -> str:
+        return self.category
+
+    def get_id(self) -> str:
+        return self.id
+
+
+ACTIVE_RIDE_OPTION = ActiveRideOption()
+

--- a/x987-app/x987/options/value_overrides.py
+++ b/x987-app/x987/options/value_overrides.py
@@ -1,0 +1,47 @@
+"""
+Options value overrides per model/generation from config.
+"""
+
+from typing import Optional, Dict, Any
+
+from x987.config.manager import get_config
+from x987.vehicles import get_vehicle_catalog
+
+
+def _get_generation_code(model: Optional[str], year: Optional[int]) -> Optional[str]:
+    if not model or not year:
+        return None
+    for m in get_vehicle_catalog():
+        if m.name.lower() == model.lower():
+            for g in m.generations:
+                if (g.min_year is None or year >= g.min_year) and (g.max_year is None or year <= g.max_year):
+                    return g.code
+    return None
+
+
+def get_override_value(option_id: str, model: Optional[str], year: Optional[int]) -> Optional[int]:
+    """
+    Return per-generation override value for an option if available.
+    """
+    cfg = get_config().get('options_per_generation', {}) or {}
+    if not cfg or not model:
+        return None
+    model_map: Dict[str, Any] = cfg.get(model, {}) or {}
+    if not model_map:
+        return None
+    gen_code = _get_generation_code(model, year)
+    if gen_code is None:
+        return None
+    gen_map: Dict[str, Any] = model_map.get(gen_code, {}) or {}
+    msrp_map: Dict[str, Any] = gen_map.get('msrp', {}) or {}
+    if not msrp_map:
+        return None
+    # Normalize keys: option IDs in config can be quoted; compare case-insensitively
+    for k, v in msrp_map.items():
+        try:
+            if str(k).lower() == str(option_id).lower():
+                return int(v)
+        except Exception:
+            continue
+    return None
+

--- a/x987-app/x987/pipeline/steps/catalog.py
+++ b/x987-app/x987/pipeline/steps/catalog.py
@@ -1,0 +1,67 @@
+"""
+Catalog Step - Exports generation catalog JSON for FE/docs
+
+This step runs late in the pipeline to generate a compact JSON catalog of
+models → generations → trims and options (with MSRP) for the FE to consume.
+
+PROVIDES: Generation catalog JSON for UI/documentation
+DEPENDS: transformation (ensures config loaded; heavy work already done)
+CONSUMED BY: x987-web FE via /api/catalog/generations
+CONTRACT: Writes generation_catalog.json to a well-known location
+TECH CHOICE: Use existing exporter module (single source of truth)
+RISK: Low - generation metadata export is read-only and side-effect is a JSON file
+"""
+
+from pathlib import Path
+from typing import Dict, Any, List
+from datetime import datetime
+
+from .base import BasePipelineStep, StepResult
+
+
+class CatalogStep(BasePipelineStep):
+    """Exports the generation catalog JSON after transformation"""
+
+    def get_step_name(self) -> str:
+        return "catalog"
+
+    def get_description(self) -> str:
+        return "Exports generation catalog JSON for FE consumption"
+
+    def get_dependencies(self) -> List[str]:
+        # Run after ranking so the catalog export happens at the end of heavy steps
+        return ["ranking"]
+
+    def get_required_config(self) -> List[str]:
+        return []
+
+    def run_step(self, config: Dict[str, Any], previous_results: Dict[str, StepResult], **kwargs) -> Any:
+        start = datetime.now()
+        try:
+            from x987.catalog.export import export_generation_catalog_json
+            # Resolve repo root robustly via config dir
+            from x987.config.manager import get_config_dir
+            repo_root = get_config_dir().parent
+
+            # Primary: FE API data path
+            fe_api_path = repo_root / 'x987-web' / 'apps' / 'api' / 'data' / 'generation_catalog.json'
+            out1 = export_generation_catalog_json(fe_api_path)
+
+            # Secondary: x987-data metadata path (for other consumers)
+            data_meta_path = repo_root / 'x987-data' / 'metadata' / 'generation_catalog.json'
+            out2 = export_generation_catalog_json(data_meta_path)
+
+            return {
+                "ok": True,
+                "paths": [str(out1), str(out2)],
+                "catalog_type": "generations"
+            }
+        except Exception as e:
+            return {
+                "ok": False,
+                "error": str(e)
+            }
+
+
+# Export the step instance for registry discovery
+CATALOG_STEP = CatalogStep()

--- a/x987-app/x987/vehicles.py
+++ b/x987-app/x987/vehicles.py
@@ -1,0 +1,195 @@
+"""
+Vehicle catalog utilities: configurable model/trim detection.
+
+PROVIDES: Detects canonical model and trim from free text using config-driven catalog.
+DEPENDS: x987.config.manager for config access.
+CONTRACT: Returns (model, trim) where both are canonical names when detected.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from .config.manager import get_config
+
+
+@dataclass
+class TrimEntry:
+    name: str
+    synonyms: List[str]
+
+
+@dataclass
+class GenerationEntry:
+    code: str
+    min_year: Optional[int]
+    max_year: Optional[int]
+    trims: List[TrimEntry]
+
+
+@dataclass
+class ModelEntry:
+    name: str
+    synonyms: List[str]
+    trims: List[TrimEntry]
+    generations: List[GenerationEntry]
+
+
+def _compile_word_pattern(terms: List[str]) -> re.Pattern:
+    # Use word boundaries; allow dots/spaces between tokens (e.g., "GT3 RS")
+    escaped = [re.escape(t) for t in terms if t and t.strip()]
+    # Prioritize longer phrases by ordering handled at call site; regex matches any
+    pattern = r"\b(?:" + r"|".join(escaped) + r")\b"
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def _load_catalog() -> List[ModelEntry]:
+    cfg: Dict[str, Any] = get_config().get('vehicles', {}) or {}
+    models_cfg: Dict[str, Any] = cfg.get('models', {}) or {}
+
+    catalog: List[ModelEntry] = []
+    for key, val in models_cfg.items():
+        if not isinstance(val, dict):
+            continue
+        name = str(val.get('name') or key)
+        synonyms = [str(s) for s in (val.get('synonyms') or []) if str(s).strip()]
+        trims_cfg = val.get('trims') or []
+        trims: List[TrimEntry] = []
+        # trims can be TOML arrays of tables [[...]] or dict map; handle both
+        if isinstance(trims_cfg, list):
+            for t in trims_cfg:
+                if not isinstance(t, dict):
+                    continue
+                t_name = str(t.get('name') or '').strip()
+                t_syn = [str(s) for s in (t.get('synonyms') or []) if str(s).strip()]
+                if t_name:
+                    trims.append(TrimEntry(name=t_name, synonyms=t_syn))
+        elif isinstance(trims_cfg, dict):
+            for t_name, syns in trims_cfg.items():
+                t_name_s = str(t_name).strip()
+                if not t_name_s:
+                    continue
+                if isinstance(syns, list):
+                    t_syn = [str(s) for s in syns if str(s).strip()]
+                else:
+                    t_syn = [str(syns)] if syns else []
+                trims.append(TrimEntry(name=t_name_s, synonyms=t_syn))
+        # generations
+        gens_cfg = val.get('generations') or []
+        generations: List[GenerationEntry] = []
+        if isinstance(gens_cfg, list):
+            for g in gens_cfg:
+                if not isinstance(g, dict):
+                    continue
+                code = str(g.get('code') or '').strip()
+                years = g.get('years') or {}
+                min_year = None
+                max_year = None
+                if isinstance(years, dict):
+                    my = years.get('min')
+                    mx = years.get('max')
+                    try:
+                        min_year = int(my) if my is not None else None
+                    except Exception:
+                        min_year = None
+                    try:
+                        max_year = int(mx) if mx is not None else None
+                    except Exception:
+                        max_year = None
+                g_trims_raw = g.get('trims') or []
+                g_trims: List[TrimEntry] = []
+                if isinstance(g_trims_raw, list):
+                    for t in g_trims_raw:
+                        if not isinstance(t, dict):
+                            continue
+                        t_name = str(t.get('name') or '').strip()
+                        t_syn = [str(s) for s in (t.get('synonyms') or []) if str(s).strip()]
+                        if t_name:
+                            g_trims.append(TrimEntry(name=t_name, synonyms=t_syn))
+                generations.append(GenerationEntry(code=code, min_year=min_year, max_year=max_year, trims=g_trims))
+
+        catalog.append(ModelEntry(name=name, synonyms=synonyms, trims=trims, generations=generations))
+
+    return catalog
+
+
+_CATALOG_CACHE: Optional[List[ModelEntry]] = None
+
+
+def get_vehicle_catalog() -> List[ModelEntry]:
+    global _CATALOG_CACHE
+    if _CATALOG_CACHE is None:
+        _CATALOG_CACHE = _load_catalog()
+    return _CATALOG_CACHE
+
+
+def reload_catalog():
+    global _CATALOG_CACHE
+    _CATALOG_CACHE = None
+
+
+def detect_model_and_trim(text: str, year: Optional[int] = None) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Detect canonical model and trim from text using config-driven catalog.
+
+    Prefers more specific trims first by checking longer synonyms before shorter ones.
+    """
+    if not text:
+        return None, None
+    catalog = get_vehicle_catalog()
+    if not catalog:
+        return None, None
+
+    # Normalize spacing
+    s = str(text)
+
+    detected_model: Optional[ModelEntry] = None
+    # Find model by synonyms
+    for model in catalog:
+        if not model.synonyms:
+            continue
+        model_pat = _compile_word_pattern(sorted(model.synonyms, key=len, reverse=True))
+        if model_pat.search(s):
+            detected_model = model
+            break
+
+    if not detected_model:
+        return None, None
+
+    # Find the most specific trim, preferring generation that matches year
+    detected_trim: Optional[str] = None
+    candidate_trims: List[TrimEntry] = []
+
+    if year is not None and detected_model.generations:
+        # Select generation that matches year
+        for g in detected_model.generations:
+            if g.min_year is not None and year < g.min_year:
+                continue
+            if g.max_year is not None and year > g.max_year:
+                continue
+            candidate_trims.extend(g.trims)
+            break
+
+    # Fallback to union of all generation trims and model-level trims
+    if not candidate_trims:
+        all_gen_trims: List[TrimEntry] = []
+        for g in detected_model.generations:
+            all_gen_trims.extend(g.trims)
+        candidate_trims = all_gen_trims + detected_model.trims
+
+    # Build an ordered list of (trim_name, synonyms_sorted)
+    ordered_trims: List[Tuple[str, List[str]]] = []
+    for t in candidate_trims:
+        syns = sorted(list(dict.fromkeys(t.synonyms + [t.name])), key=len, reverse=True)
+        ordered_trims.append((t.name, syns))
+
+    # Check longer synonyms first to avoid "Carrera" matching before "Carrera 4S"
+    for t_name, syns in sorted(ordered_trims, key=lambda x: max(len(s) for s in x[1]), reverse=True):
+        pat = _compile_word_pattern(syns)
+        if pat.search(s):
+            detected_trim = t_name
+            break
+
+    return detected_model.name, detected_trim

--- a/x987-config/config.toml
+++ b/x987-config/config.toml
@@ -1,10 +1,14 @@
 [search]
 urls = [
     #"https://www.autotempest.com/results?keywords=black%20edition&localization=country&make=porsche&maxyear=2012&minyear=2009&model=cayman&transmission=auto&zip=30214",
-    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=cayman&transmission=auto&zip=30214",
-    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=boxster&transmission=auto&zip=30214",
-    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2008&minyear=2005&model=boxster&transmission=auto&zip=30214",
-    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2008&minyear=2005&model=cayman&transmission=auto&zip=30214",
+    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=cayman&transmission=auto&zip=30214",
+    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=boxster&transmission=auto&zip=30214",
+    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2008&minyear=2005&model=boxster&transmission=auto&zip=30214",
+    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2008&minyear=2005&model=cayman&transmission=auto&zip=30214",
+    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2004&minyear=1999&model=911&transmission=auto&zip=30214",
+    #"https://www.autotempest.com/results?keywords=gts&localization=country&make=porsche&maxmiles=70000&maxprice=42000&minmiles=15000&minprice=39000&minyear=2018&model=macan&transmission=auto&zip=30214",
+    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=cayman&transmission=auto&trim_kw=S&zip=30214",
+    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=boxster&transmission=auto&trim_kw=S&zip=30214",
 ]
 
 [fair_value]
@@ -39,8 +43,6 @@ PASM = 1990           # PASM
 LSD = 890             # LSD (module ID)
 XLF = 2500            # Sport Exhaust (PSE)
 PSE = 2500            # Sport Exhaust (module ID)
-"250" = 3200         # PDK (code)
-PDK = 3200            # PDK (module ID)
 SSEAT = 1525          # Sport Seats / Adaptive Sport Seats (code)
 "Sport Seats" = 1525 # Sport Seats (module ID)
 HTD = 500             # Heated Seats (code)
@@ -55,6 +57,7 @@ BIX = 1360            # Bi-Xenon Headlights with Dynamic Cornering (code)
 "Bi-Xenon" = 1360    # Bi-Xenon Headlights (module ID)
 "19W" = 1500         # 18–19" Upgraded Wheels (code)
 Wheels = 1500         # 18–19" Upgraded Wheels (module ID)
+ACTIVE_RIDE = 7140    # Porsche Active Ride (Adaptive Suspension) - Taycan 9J1 (fallback MSRP)
 [options_v2.catalog]
 # Performance Options
 [[options_v2.catalog.performance]]
@@ -186,13 +189,809 @@ patterns = [
 ]
 standard_on_trims = ["Cayman R"]
 
-# Transmission (stored but not displayed)
-[[options_v2.catalog.performance]]
-id = "250"
-display = "PDK"
-value_usd = 0
-patterns = [
-    "pdk", "7-speed pdk", "porsche doppelkupplung", "7 speed pdk",
-    "7-speed automatic", "7 speed automatic"
+# =============================
+# Vehicle Catalog (Models/Trims)
+# =============================
+# This catalog powers model/trim detection in Python (and can be mirrored in FE).
+# It's designed to be easily extended as we add more models and generations.
+
+[vehicles]
+
+# Each model entry defines canonical name, synonyms, and trims with their own synonyms.
+# Detection prefers more specific trims first (e.g., Carrera 4S over Carrera 4 over Carrera).
+[vehicles.models.911]
+name = "911"
+synonyms = ["911"]
+
+[[vehicles.models.911.trims]]
+name = "Carrera"
+synonyms = ["Carrera", "C2", "Carrera 2"]
+
+[[vehicles.models.911.trims]]
+name = "Carrera 4"
+synonyms = ["Carrera 4", "C4"]
+
+[[vehicles.models.911.trims]]
+name = "Carrera 4S"
+synonyms = ["Carrera 4S", "C4S"]
+
+[[vehicles.models.911.trims]]
+name = "Carrera S"
+synonyms = ["Carrera S"]
+
+[[vehicles.models.911.trims]]
+name = "Targa"
+synonyms = ["Targa"]
+
+[[vehicles.models.911.trims]]
+name = "Turbo"
+synonyms = ["Turbo", "Turbo S"]
+
+[[vehicles.models.911.trims]]
+name = "GT3"
+synonyms = ["GT3", "GT3 RS"]
+
+[[vehicles.models.911.trims]]
+name = "GT2"
+synonyms = ["GT2", "GT2 RS"]
+
+# Example entries for Boxster/Cayman (kept minimal; extend as needed)
+[vehicles.models.Cayman]
+name = "Cayman"
+synonyms = ["Cayman"]
+
+[[vehicles.models.Cayman.trims]]
+name = "Base"
+synonyms = ["Base"]
+
+[[vehicles.models.Cayman.trims]]
+name = "S"
+synonyms = ["S"]
+
+[[vehicles.models.Cayman.trims]]
+name = "R"
+synonyms = ["R"]
+
+[vehicles.models.Boxster]
+name = "Boxster"
+synonyms = ["Boxster"]
+
+[[vehicles.models.Boxster.trims]]
+name = "Base"
+synonyms = ["Base"]
+
+[[vehicles.models.Boxster.trims]]
+name = "S"
+synonyms = ["S"]
+
+[[vehicles.models.Boxster.trims]]
+name = "Spyder"
+synonyms = ["Spyder"]
+
+# ============
+# Generations
+# ============
+
+# 911 Generations
+[[vehicles.models.911.generations]]
+code = "996"
+years = { min = 1999, max = 2004 }
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera"
+  synonyms = ["Carrera", "Carrera 2", "C2"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4"
+  synonyms = ["Carrera 4", "C4"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4S"
+  synonyms = ["Carrera 4S", "C4S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Targa"
+  synonyms = ["Targa"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3"
+  synonyms = ["GT3"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT2"
+  synonyms = ["GT2"]
+
+[[vehicles.models.911.generations]]
+code = "997.1"
+years = { min = 2005, max = 2008 }
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera"
+  synonyms = ["Carrera", "C2"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera S"
+  synonyms = ["Carrera S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4"
+  synonyms = ["Carrera 4", "C4"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4S"
+  synonyms = ["Carrera 4S", "C4S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Targa"
+  synonyms = ["Targa"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3"
+  synonyms = ["GT3"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT2"
+  synonyms = ["GT2"]
+
+[[vehicles.models.911.generations]]
+code = "997.2"
+years = { min = 2009, max = 2012 }
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera"
+  synonyms = ["Carrera", "C2"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera S"
+  synonyms = ["Carrera S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4"
+  synonyms = ["Carrera 4", "C4"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4S"
+  synonyms = ["Carrera 4S", "C4S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Targa"
+  synonyms = ["Targa"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3"
+  synonyms = ["GT3"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT2"
+  synonyms = ["GT2"]
+
+[[vehicles.models.911.generations]]
+code = "991.1"
+years = { min = 2012, max = 2016 }
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera"
+  synonyms = ["Carrera"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera S"
+  synonyms = ["Carrera S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4"
+  synonyms = ["Carrera 4"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4S"
+  synonyms = ["Carrera 4S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Targa"
+  synonyms = ["Targa"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo S"
+  synonyms = ["Turbo S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3"
+  synonyms = ["GT3"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3 RS"
+  synonyms = ["GT3 RS"]
+
+[[vehicles.models.911.generations]]
+code = "991.2"
+years = { min = 2017, max = 2019 }
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera"
+  synonyms = ["Carrera"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera S"
+  synonyms = ["Carrera S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera GTS"
+  synonyms = ["Carrera GTS", "GTS"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4"
+  synonyms = ["Carrera 4"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4S"
+  synonyms = ["Carrera 4S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4 GTS"
+  synonyms = ["Carrera 4 GTS", "4 GTS"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Targa"
+  synonyms = ["Targa"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo S"
+  synonyms = ["Turbo S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3"
+  synonyms = ["GT3"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3 RS"
+  synonyms = ["GT3 RS"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT2 RS"
+  synonyms = ["GT2 RS"]
+
+[[vehicles.models.911.generations]]
+code = "992"
+years = { min = 2020, max = 2025 }
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera"
+  synonyms = ["Carrera"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera S"
+  synonyms = ["Carrera S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera GTS"
+  synonyms = ["Carrera GTS", "GTS"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4"
+  synonyms = ["Carrera 4"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4S"
+  synonyms = ["Carrera 4S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Carrera 4 GTS"
+  synonyms = ["Carrera 4 GTS", "4 GTS"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Targa"
+  synonyms = ["Targa"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Turbo S"
+  synonyms = ["Turbo S"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3"
+  synonyms = ["GT3"]
+  [[vehicles.models.911.generations.trims]]
+  name = "GT3 RS"
+  synonyms = ["GT3 RS"]
+  [[vehicles.models.911.generations.trims]]
+  name = "Dakar"
+  synonyms = ["Dakar"]
+  [[vehicles.models.911.generations.trims]]
+  name = "ST"
+  synonyms = ["ST"]
+
+# Cayman Generations
+[[vehicles.models.Cayman.generations]]
+code = "987.1"
+years = { min = 2005, max = 2008 }
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+
+[[vehicles.models.Cayman.generations]]
+code = "987.2"
+years = { min = 2009, max = 2012 }
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "R"
+  synonyms = ["R"]
+
+[[vehicles.models.Cayman.generations]]
+code = "981"
+years = { min = 2013, max = 2016 }
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "Spyder"
+  synonyms = ["Spyder"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "GT4"
+  synonyms = ["GT4"]
+
+[[vehicles.models.Cayman.generations]]
+code = "982/718"
+years = { min = 2017, max = 2025 }
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "T"
+  synonyms = ["T"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "GTS 4.0"
+  synonyms = ["GTS 4.0"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "GT4"
+  synonyms = ["GT4"]
+  [[vehicles.models.Cayman.generations.trims]]
+  name = "Spyder"
+  synonyms = ["Spyder"]
+
+# Boxster Generations
+[[vehicles.models.Boxster.generations]]
+code = "986"
+years = { min = 1997, max = 2004 }
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+
+[[vehicles.models.Boxster.generations]]
+code = "987.1"
+years = { min = 2005, max = 2008 }
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+
+[[vehicles.models.Boxster.generations]]
+code = "987.2"
+years = { min = 2009, max = 2012 }
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Spyder"
+  synonyms = ["Spyder"]
+
+[[vehicles.models.Boxster.generations]]
+code = "981"
+years = { min = 2013, max = 2016 }
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Spyder"
+  synonyms = ["Spyder"]
+
+[[vehicles.models.Boxster.generations]]
+code = "982/718"
+years = { min = 2017, max = 2025 }
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "T"
+  synonyms = ["T"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "GTS 4.0"
+  synonyms = ["GTS 4.0"]
+  [[vehicles.models.Boxster.generations.trims]]
+  name = "Spyder"
+  synonyms = ["Spyder"]
+
+# Cayenne Models
+[vehicles.models.Cayenne]
+name = "Cayenne"
+synonyms = ["Cayenne"]
+
+[[vehicles.models.Cayenne.generations]]
+code = "955/957"
+years = { min = 2003, max = 2010 }
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+
+[[vehicles.models.Cayenne.generations]]
+code = "958.1"
+years = { min = 2011, max = 2014 }
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo S"
+  synonyms = ["Turbo S"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Hybrid"
+  synonyms = ["Hybrid"]
+
+[[vehicles.models.Cayenne.generations]]
+code = "958.2"
+years = { min = 2015, max = 2018 }
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo S"
+  synonyms = ["Turbo S"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Hybrid"
+  synonyms = ["Hybrid"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "E-Hybrid"
+  synonyms = ["E-Hybrid", "E Hybrid"]
+
+[[vehicles.models.Cayenne.generations]]
+code = "9Y0"
+years = { min = 2019, max = 2025 }
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Base"
+  synonyms = ["Base", "Coupe Base", "Base Coupe"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "S"
+  synonyms = ["S", "S Coupe", "Coupe S"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS", "GTS Coupe", "Coupe GTS"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo", "Turbo Coupe", "Coupe Turbo"]
+  [[vehicles.models.Cayenne.generations.trims]]
+  name = "Turbo S E-Hybrid"
+  synonyms = ["Turbo S E-Hybrid", "Turbo S E Hybrid", "Turbo S E-Hybrid Coupe", "Turbo S E Hybrid Coupe"]
+
+# Panamera Models
+[vehicles.models.Panamera]
+name = "Panamera"
+synonyms = ["Panamera"]
+
+[[vehicles.models.Panamera.generations]]
+code = "970.1"
+years = { min = 2010, max = 2013 }
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "4S"
+  synonyms = ["4S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Hybrid"
+  synonyms = ["Hybrid"]
+
+[[vehicles.models.Panamera.generations]]
+code = "970.2"
+years = { min = 2014, max = 2016 }
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "4S"
+  synonyms = ["4S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Hybrid"
+  synonyms = ["Hybrid"]
+
+[[vehicles.models.Panamera.generations]]
+code = "971.1"
+years = { min = 2017, max = 2020 }
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "4S"
+  synonyms = ["4S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "E-Hybrid"
+  synonyms = ["E-Hybrid", "E Hybrid"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Turbo S E-Hybrid"
+  synonyms = ["Turbo S E-Hybrid", "Turbo S E Hybrid"]
+
+[[vehicles.models.Panamera.generations]]
+code = "971.2"
+years = { min = 2021, max = 2025 }
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "4S"
+  synonyms = ["4S"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "E-Hybrid"
+  synonyms = ["E-Hybrid", "E Hybrid"]
+  [[vehicles.models.Panamera.generations.trims]]
+  name = "Turbo S E-Hybrid"
+  synonyms = ["Turbo S E-Hybrid", "Turbo S E Hybrid"]
+
+# Macan Models
+[vehicles.models.Macan]
+name = "Macan"
+synonyms = ["Macan"]
+
+[[vehicles.models.Macan.generations]]
+code = "95B.1"
+years = { min = 2015, max = 2018 }
+  [[vehicles.models.Macan.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+
+[[vehicles.models.Macan.generations]]
+code = "95B.2"
+years = { min = 2019, max = 2023 }
+  [[vehicles.models.Macan.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+
+[[vehicles.models.Macan.generations]]
+code = "95B.3"
+years = { min = 2024, max = 2025 }
+  [[vehicles.models.Macan.generations.trims]]
+  name = "Base"
+  synonyms = ["Base"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "S"
+  synonyms = ["S"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "T"
+  synonyms = ["T"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS"]
+
+[[vehicles.models.Macan.generations]]
+code = "Macan Electric (PPE)"
+years = { min = 2025 }
+  [[vehicles.models.Macan.generations.trims]]
+  name = "4"
+  synonyms = ["Macan 4", "4"]
+  [[vehicles.models.Macan.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Macan Turbo", "Turbo"]
+
+# Taycan Models
+[vehicles.models.Taycan]
+name = "Taycan"
+synonyms = ["Taycan"]
+
+[[vehicles.models.Taycan.generations]]
+code = "9J1"
+years = { min = 2020, max = 2025 }
+  [[vehicles.models.Taycan.generations.trims]]
+  name = "4S"
+  synonyms = ["4S", "4S Cross Turismo", "Cross Turismo 4S", "4S Sport Turismo"]
+  [[vehicles.models.Taycan.generations.trims]]
+  name = "Turbo"
+  synonyms = ["Turbo", "Turbo Cross Turismo", "Turbo Sport Turismo"]
+  [[vehicles.models.Taycan.generations.trims]]
+  name = "Turbo S"
+  synonyms = ["Turbo S", "Turbo S Cross Turismo", "Turbo S Sport Turismo"]
+  [[vehicles.models.Taycan.generations.trims]]
+  name = "GTS"
+  synonyms = ["GTS", "GTS Sport Turismo"]
+
+# =============================
+# Options Per Generation (MSRP overrides / defaults)
+# =============================
+[options_per_generation.defaults]
+# Default "top options" used across models/generations
+top_options = [
+    "639/640",  # Sport Chrono
+    "PASM",     # PASM
+    "PSE",      # Sport Exhaust
+    "LSD",      # Limited Slip Differential
+    "Sport Seats", # Sport/Adaptive Sport Seats
+    "HTD",      # Heated Seats
+    "PCM",      # PCM w/ Navigation
+    "BOSE",     # BOSE
+    "BIX",      # Bi-Xenon
+    "19W",      # 18–19" Wheels
+    "PARK"      # Park Assist
 ]
-standard_on_trims = []
+
+[options_per_generation.911]
+  [options_per_generation.911."996".msrp]
+  PASM = 1990                # 474
+  "639/640" = 920            # Sport Chrono (640)
+  PSE = 2400                 # XLF / 09991
+  X51 = 15000                # X51 Power Kit
+  "Sport Seats" = 1550       # P01 / 982
+  HTD = 500                  # 342
+  BOSE = 1390                # 680
+  PCM = 3070                 # 670
+  LSD = 950                  # 220
+  SHORT_SHIFTER = 765        # X97/X98
+  BIX = 1090                 # 601
+  DIM_RAIN = 690             # 635
+  SPORT_WHEEL = 330          # 435/XPD
+  "19W" = 2000               # midpoint of 1390–2440
+  Wheels = 2000
+
+  [options_per_generation.911."997.1".msrp]
+  PASM = 1990
+  "639/640" = 920
+  PSE = 2400
+  X51 = 15000
+  "Sport Seats" = 1550
+  HTD = 500
+  BOSE = 1390
+  PCM = 3070
+  LSD = 950
+  SHORT_SHIFTER = 765
+  BIX = 1090
+  DIM_RAIN = 690
+  SPORT_WHEEL = 330
+  "19W" = 2000
+  Wheels = 2000
+
+  [options_per_generation.911."997.2".msrp]
+  PASM = 1990
+  "639/640" = 920
+  PSE = 2400
+  X51 = 15000
+  "Sport Seats" = 1550
+  HTD = 500
+  BOSE = 1390
+  PCM = 3070
+  LSD = 950
+  SHORT_SHIFTER = 765
+  BIX = 1090
+  DIM_RAIN = 690
+  SPORT_WHEEL = 330
+  "19W" = 2000
+  Wheels = 2000
+
+[options_per_generation.Macan]
+  [options_per_generation.Macan."95B.1".msrp]
+  PASM = 1390                # 475
+  "639/640" = 1360           # Sport Chrono (8LH)
+  PSE = 1590                 # 0P9
+  "Sport Seats" = 2560       # midpoint 1710–3440 (14/18-way)
+  BOSE = 990                 # 9VL
+  Bi-Xenon = 770             # PDLS (LEDs) mapping for detection
+  PCM = 1730                 # I8T Navigation
+  HEATED_REAR = 385          # 4A3
+
+  [options_per_generation.Macan."95B.2".msrp]
+  PASM = 1390
+  "639/640" = 1360
+  PSE = 1590
+  "Sport Seats" = 2560
+  BOSE = 990
+  Bi-Xenon = 770
+  PCM = 1730
+  HEATED_REAR = 385
+
+# 987.2 Cayman/Boxster: per-generation options MSRP (using base catalog values)
+[options_per_generation.Cayman]
+  [options_per_generation.Cayman."987.2".msrp]
+  "639/640" = 960
+  PASM = 1990
+  PSE = 2500
+  "Sport Seats" = 1525
+  HTD = 500
+  PCM = 3265
+  BOSE = 1350
+  BIX = 1360
+  "19W" = 1500
+  LSD = 890
+
+[options_per_generation.Boxster]
+  [options_per_generation.Boxster."987.2".msrp]
+  "639/640" = 960
+  PASM = 1990
+  PSE = 2500
+  "Sport Seats" = 1525
+  HTD = 500
+  PCM = 3265
+  BOSE = 1350
+  BIX = 1360
+  "19W" = 1500

--- a/x987-web/apps/api/data/generation_catalog.json
+++ b/x987-web/apps/api/data/generation_catalog.json
@@ -1,0 +1,836 @@
+{
+  "schema_version": 1,
+  "source": "manual_research",
+  "models": [
+    {
+      "name": "Cayman",
+      "synonyms": [
+        "Cayman"
+      ],
+      "generations": [
+        {
+          "key": "Cayman-987.1",
+          "code": "987.1",
+          "years": {
+            "min": 2005,
+            "max": 2008
+          },
+          "trims": [
+            "Base",
+            "S"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Cayman-987.2",
+          "code": "987.2",
+          "years": {
+            "min": 2009,
+            "max": 2012
+          },
+          "trims": [
+            "Base",
+            "S",
+            "R"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Cayman-981",
+          "code": "981",
+          "years": {
+            "min": 2013,
+            "max": 2016
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "GT4"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "639/640",
+              "display": "Sport Chrono Package Plus",
+              "msrp": 1850
+            },
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1790
+            },
+            {
+              "id": "PSE",
+              "display": "Sport Exhaust (PSE)",
+              "msrp": 2440
+            },
+            {
+              "id": "PCM",
+              "display": "PCM w/ Navigation",
+              "msrp": 4000
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1400
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2730
+            }
+          ],
+          "options_default": false
+        },
+        {
+          "key": "Cayman-982",
+          "code": "982",
+          "years": {
+            "min": 2017,
+            "max": 2025
+          },
+          "trims": [
+            "Base",
+            "T",
+            "S",
+            "GTS 4.0",
+            "GT4",
+            "GT4 RS"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "639/640",
+              "display": "Sport Chrono Package Plus",
+              "msrp": 2440
+            },
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1790
+            },
+            {
+              "id": "PSE",
+              "display": "Sport Exhaust (PSE)",
+              "msrp": 2395
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1400
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2000
+            }
+          ],
+          "options_default": false
+        }
+      ]
+    },
+    {
+      "name": "Boxster",
+      "synonyms": [
+        "Boxster"
+      ],
+      "generations": [
+        {
+          "key": "Boxster-986",
+          "code": "986",
+          "years": {
+            "min": 1997,
+            "max": 2004
+          },
+          "trims": [
+            "Base",
+            "S"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Boxster-987.1",
+          "code": "987.1",
+          "years": {
+            "min": 2005,
+            "max": 2008
+          },
+          "trims": [
+            "Base",
+            "S"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Boxster-987.2",
+          "code": "987.2",
+          "years": {
+            "min": 2009,
+            "max": 2012
+          },
+          "trims": [
+            "Base",
+            "S",
+            "Spyder"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Boxster-981",
+          "code": "981",
+          "years": {
+            "min": 2013,
+            "max": 2016
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Spyder"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "639/640",
+              "display": "Sport Chrono Package Plus",
+              "msrp": 1850
+            },
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1790
+            },
+            {
+              "id": "PSE",
+              "display": "Sport Exhaust (PSE)",
+              "msrp": 2440
+            },
+            {
+              "id": "PCM",
+              "display": "PCM w/ Navigation",
+              "msrp": 4000
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1400
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2730
+            }
+          ],
+          "options_default": false
+        },
+        {
+          "key": "Boxster-982",
+          "code": "982",
+          "years": {
+            "min": 2017,
+            "max": 2025
+          },
+          "trims": [
+            "Base",
+            "T",
+            "S",
+            "GTS 4.0",
+            "Spyder",
+            "Spyder RS"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "639/640",
+              "display": "Sport Chrono Package Plus",
+              "msrp": 2440
+            },
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1790
+            },
+            {
+              "id": "PSE",
+              "display": "Sport Exhaust (PSE)",
+              "msrp": 2395
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1400
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2000
+            }
+          ],
+          "options_default": false
+        }
+      ]
+    },
+    {
+      "name": "911",
+      "synonyms": [
+        "911"
+      ],
+      "generations": [
+        {
+          "key": "911-996",
+          "code": "996",
+          "years": {
+            "min": 1999,
+            "max": 2004
+          },
+          "trims": [
+            "Carrera",
+            "Carrera 4",
+            "Carrera 4S",
+            "Targa",
+            "Turbo",
+            "GT3",
+            "GT2"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "911-997.1",
+          "code": "997.1",
+          "years": {
+            "min": 2005,
+            "max": 2008
+          },
+          "trims": [
+            "Carrera",
+            "Carrera S",
+            "Carrera 4",
+            "Carrera 4S",
+            "Targa",
+            "Turbo",
+            "GT3",
+            "GT2"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "911-997.2",
+          "code": "997.2",
+          "years": {
+            "min": 2009,
+            "max": 2012
+          },
+          "trims": [
+            "Carrera",
+            "Carrera S",
+            "Carrera 4",
+            "Carrera 4S",
+            "Targa",
+            "Turbo",
+            "GT3",
+            "GT2"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "911-991.1",
+          "code": "991.1",
+          "years": {
+            "min": 2012,
+            "max": 2016
+          },
+          "trims": [
+            "Carrera",
+            "Carrera S",
+            "Carrera 4",
+            "Carrera 4S",
+            "Targa 4",
+            "Targa 4S",
+            "Turbo",
+            "Turbo S",
+            "GT3",
+            "GT3 RS",
+            "GTS"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "911-991.2",
+          "code": "991.2",
+          "years": {
+            "min": 2017,
+            "max": 2019
+          },
+          "trims": [
+            "Carrera",
+            "Carrera T",
+            "Carrera S",
+            "Carrera 4",
+            "Carrera 4S",
+            "Targa 4",
+            "Targa 4S",
+            "Turbo",
+            "Turbo S",
+            "GT3",
+            "GT3 RS",
+            "GT2 RS",
+            "GTS"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "911-992",
+          "code": "992",
+          "years": {
+            "min": 2020,
+            "max": 2025
+          },
+          "trims": [
+            "Carrera",
+            "Carrera T",
+            "Carrera S",
+            "Carrera 4",
+            "Carrera 4S",
+            "Targa 4",
+            "Targa 4S",
+            "GTS",
+            "Turbo",
+            "Turbo S",
+            "GT3",
+            "GT3 RS",
+            "Dakar",
+            "S/T"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "639/640",
+              "display": "Sport Chrono Package Plus",
+              "msrp": 2720
+            },
+            {
+              "id": "PSE",
+              "display": "Sport Exhaust (PSE)",
+              "msrp": 2950
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1600
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 3270
+            },
+            {
+              "id": "SPORT_WHEEL",
+              "display": "Sport Steering Wheel",
+              "msrp": 800
+            }
+          ],
+          "options_default": false
+        }
+      ]
+    },
+    {
+      "name": "Cayenne",
+      "synonyms": [
+        "Cayenne"
+      ],
+      "generations": [
+        {
+          "key": "Cayenne-955/957",
+          "code": "955/957",
+          "years": {
+            "min": 2003,
+            "max": 2010
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Turbo",
+            "Turbo S"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Cayenne-958.1",
+          "code": "958.1",
+          "years": {
+            "min": 2011,
+            "max": 2014
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Turbo",
+            "Turbo S",
+            "S Hybrid"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1990
+            },
+            {
+              "id": "PCM",
+              "display": "PCM w/ Navigation",
+              "msrp": 3645
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1690
+            },
+            {
+              "id": "BIX",
+              "display": "Bi-Xenon Headlights with Dynamic Cornering",
+              "msrp": 1860
+            },
+            {
+              "id": "HTD",
+              "display": "Heated Seats",
+              "msrp": 525
+            },
+            {
+              "id": "DIM_RAIN",
+              "display": "Auto-dim Mirrors & Rain Sensor",
+              "msrp": 250
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2000
+            }
+          ],
+          "options_default": false
+        },
+        {
+          "key": "Cayenne-958.2",
+          "code": "958.2",
+          "years": {
+            "min": 2015,
+            "max": 2018
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Turbo",
+            "Turbo S",
+            "S E-Hybrid"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1990
+            },
+            {
+              "id": "PCM",
+              "display": "PCM w/ Navigation",
+              "msrp": 3645
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1690
+            },
+            {
+              "id": "BIX",
+              "display": "Bi-Xenon Headlights with Dynamic Cornering",
+              "msrp": 1860
+            },
+            {
+              "id": "HTD",
+              "display": "Heated Seats",
+              "msrp": 525
+            },
+            {
+              "id": "DIM_RAIN",
+              "display": "Auto-dim Mirrors & Rain Sensor",
+              "msrp": 250
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2000
+            }
+          ],
+          "options_default": false
+        },
+        {
+          "key": "Cayenne-9Y0",
+          "code": "9Y0",
+          "years": {
+            "min": 2019,
+            "max": 2025
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Turbo",
+            "E-Hybrid",
+            "Turbo S E-Hybrid",
+            "Turbo GT"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        }
+      ]
+    },
+    {
+      "name": "Panamera",
+      "synonyms": [
+        "Panamera"
+      ],
+      "generations": [
+        {
+          "key": "Panamera-970.1",
+          "code": "970.1",
+          "years": {
+            "min": 2010,
+            "max": 2013
+          },
+          "trims": [
+            "Base",
+            "4",
+            "4S",
+            "GTS",
+            "Turbo"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Panamera-970.2",
+          "code": "970.2",
+          "years": {
+            "min": 2014,
+            "max": 2016
+          },
+          "trims": [
+            "Base",
+            "4",
+            "4S",
+            "GTS",
+            "Turbo",
+            "Turbo S",
+            "S E-Hybrid"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Panamera-971.1",
+          "code": "971.1",
+          "years": {
+            "min": 2017,
+            "max": 2020
+          },
+          "trims": [
+            "Base",
+            "4",
+            "4S",
+            "GTS",
+            "Turbo",
+            "Turbo S",
+            "4 E-Hybrid",
+            "Turbo S E-Hybrid"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Panamera-971.2",
+          "code": "971.2",
+          "years": {
+            "min": 2021,
+            "max": 2025
+          },
+          "trims": [
+            "Base",
+            "4",
+            "4S",
+            "GTS",
+            "Turbo S",
+            "4 E-Hybrid",
+            "Turbo S E-Hybrid"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        }
+      ]
+    },
+    {
+      "name": "Macan",
+      "synonyms": [
+        "Macan"
+      ],
+      "generations": [
+        {
+          "key": "Macan-95B.1",
+          "code": "95B.1",
+          "years": {
+            "min": 2015,
+            "max": 2018
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Turbo",
+            "Turbo Performance Package"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "PCM",
+              "display": "PCM w/ Navigation",
+              "msrp": 5593
+            },
+            {
+              "id": "BOSE",
+              "display": "BOSE Surround Sound",
+              "msrp": 1400
+            },
+            {
+              "id": "PASM",
+              "display": "PASM",
+              "msrp": 1365
+            },
+            {
+              "id": "19W",
+              "display": "18\u201319\" Upgraded Wheels",
+              "msrp": 2000
+            }
+          ],
+          "options_default": false
+        },
+        {
+          "key": "Macan-95B.2",
+          "code": "95B.2",
+          "years": {
+            "min": 2019,
+            "max": 2023
+          },
+          "trims": [
+            "Base",
+            "S",
+            "GTS",
+            "Turbo"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Macan-95B.3",
+          "code": "95B.3",
+          "years": {
+            "min": 2024,
+            "max": 2025
+          },
+          "trims": [
+            "Base",
+            "T",
+            "S",
+            "GTS"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        },
+        {
+          "key": "Macan-ev-2025-",
+          "code": "Macan EV",
+          "years": {
+            "min": 2025
+          },
+          "trims": [
+            "Macan 4",
+            "Macan Turbo"
+          ],
+          "trims_default": false,
+          "options": [],
+          "options_default": true
+        }
+      ]
+    },
+    {
+      "name": "Taycan",
+      "synonyms": [
+        "Taycan"
+      ],
+      "generations": [
+        {
+          "key": "Taycan-9J1",
+          "code": "9J1",
+          "years": {
+            "min": 2020,
+            "max": 2025
+          },
+          "trims": [
+            "Base",
+            "4S",
+            "GTS",
+            "Turbo",
+            "Turbo S",
+            "4 Cross Turismo",
+            "4S Cross Turismo",
+            "Turbo Cross Turismo"
+          ],
+          "trims_default": false,
+          "options": [
+            {
+              "id": "639/640",
+              "display": "Sport Chrono Package Plus",
+              "msrp": 1320
+            },
+            {
+              "id": "ACTIVE_RIDE",
+              "display": "Porsche Active Ride (Adaptive Suspension)",
+              "msrp": 7140
+            }
+          ],
+          "options_default": false
+        }
+      ]
+    }
+  ]
+}

--- a/x987-web/apps/api/src/utils/fsPaths.ts
+++ b/x987-web/apps/api/src/utils/fsPaths.ts
@@ -28,6 +28,15 @@ export function findConfigPath(): string | null {
   ])
 }
 
+export function findGenerationCatalogJson(): string | null {
+  // Look for a generated JSON catalog that FE can consume
+  return ascendCandidates([
+    path.join('x987-web', 'apps', 'api', 'data', 'generation_catalog.json'),
+    path.join('x987-data', 'metadata', 'generation_catalog.json'),
+    path.join('x987-data', 'metadata', 'generations.json')
+  ])
+}
+
 export function findLatestRankingCsv(dir: string): string | null {
   const all = fs.readdirSync(dir).filter(f => f.toLowerCase().endsWith('.csv')).sort()
   // Prefer ranking_main_*

--- a/x987-web/apps/fe/src/lib/format.ts
+++ b/x987-web/apps/fe/src/lib/format.ts
@@ -39,9 +39,42 @@ export function normalizeModelTrim(s?: string): string {
   const raw = (s || '').trim()
   if (!raw) return ''
   let t = raw.replace(/\bbase\b/gi, '')
-  t = t.replace(/\bcayman\b/gi, 'Cayman').replace(/\bboxster\b/gi, 'Boxster')
+  // Canonical model casing
+  t = t.replace(/\bcayman\b/gi, 'Cayman').replace(/\bboxster\b/gi, 'Boxster').replace(/\b911\b/gi, '911')
+  // Common special editions
   t = t.replace(/\bblack\s+edition\b/gi, 'BE')
+  // Cayman/Boxster S normalization
   t = t.replace(/\b(Cayman|Boxster)\s+s\b/gi, '$1 S')
+  // 911: normalize Carrera variants and popular abbreviations
+  // Expand C4S/C4/C2 when 911 context exists or Carrera present
+  const lower = t.toLowerCase()
+  const in911Ctx = /\b911\b/.test(lower) || /\bcarrera\b/.test(lower)
+  if (in911Ctx) {
+    t = t
+      .replace(/\bcarrera\s+4\s*s\b/gi, 'Carrera 4S')
+      .replace(/\bcarrera\s+s\b/gi, 'Carrera S')
+      .replace(/\bcarrera\s+4\b/gi, 'Carrera 4')
+      .replace(/\bcarrera\b/gi, 'Carrera')
+      .replace(/\bc4s\b/gi, 'Carrera 4S')
+      .replace(/\bc4\b/gi, 'Carrera 4')
+      .replace(/\bc2\b/gi, 'Carrera')
+      .replace(/\btarga\b/gi, 'Targa')
+      .replace(/\bturbo\s*s\b/gi, 'Turbo S')
+      .replace(/\bturbo\b/gi, 'Turbo')
+      .replace(/\bgt3\s*rs\b/gi, 'GT3 RS')
+      .replace(/\bgt2\s*rs\b/gi, 'GT2 RS')
+      .replace(/\bgt3\b/gi, 'GT3')
+      .replace(/\bgt2\b/gi, 'GT2')
+  }
+  // Generic trim token normalizations across models
+  t = t
+    .replace(/\b4\s*s\b/gi, '4S')
+    .replace(/\b4\s*gts\b/gi, '4 GTS')
+    .replace(/\be[-\s]*hybrid\b/gi, 'E-Hybrid')
+    .replace(/\bgts\s*4\.0\b/gi, 'GTS 4.0')
+    .replace(/\bturbo\s*s\b/gi, 'Turbo S')
+    .replace(/\bgt4\b/gi, 'GT4')
+    .replace(/\bgts\b/gi, 'GTS')
   return t.replace(/\s+/g, ' ').trim()
 }
 
@@ -54,7 +87,8 @@ export function shortenOption(label: string): string {
   if (low.includes('pasm') || low.includes('adaptive suspension') || low.includes('active suspension')) return 'PASM'
   if (low.includes('sport exhaust') || /\bpse\b/.test(low)) return 'Exhaust'
   if (low.includes('limited slip') || /\blsd\b/.test(low)) return 'LSD'
-  if (/\bpdk\b/.test(low)) return 'PDK'
+  // Hide transmissions; PDK/Tiptronic are assumed, not options
+  if (/\bpdk\b/.test(low)) return ''
   if (low.includes('heated seat')) return 'Heated'
   if (low.includes('ventilated') || low.includes('cooled seat')) return 'Cooled'
   if (low.includes('sport seat') || low.includes('adaptive sport')) return 'Seats'
@@ -74,4 +108,3 @@ export function optionsCompact(opt: string | string[] | undefined): string {
   const arr = Array.isArray(opt) ? opt : String(opt).split(',').map(s => s.trim()).filter(Boolean)
   return arr.map(shortenOption).filter(Boolean).join(', ')
 }
-


### PR DESCRIPTION
# Porsche multi‑model support: generations + options MSRP + FE catalog; Taycan Active Ride

## Motivation
Scale beyond 987.x by modeling Porsche families → generations → trims in a config‑driven way. Show generation‑specific options with MSRP in the UI and use them in pipeline output. Add recent, high‑impact Taycan option (Porsche Active Ride) for the 2025 9J1 refresh.

## Summary
- Year‑aware vehicle catalog detection (Python)
- Options detection totals include per‑generation MSRP (config/JSON)
- Catalog pipeline step exports `generation_catalog.json` for FE/docs
- FE shows trims and options ($MSRP) under Generation; Controls tab shows full readable dump
- New option: ACTIVE_RIDE for Taycan 9J1 (+ MSRP fallback)
- Normalized generation codes (982, 9Y0, 9J1, 971.2) in catalog JSON

## Key Changes
- Python
  - `x987-app/x987/vehicles.py` — year‑aware model/trim detection
  - `x987-app/x987/options/value_overrides.py` — per‑gen MSRP resolver
  - `x987-app/x987/options/active_ride.py` — ACTIVE_RIDE option (Taycan 9J1)
  - `x987-app/x987/pipeline/steps/transformation.py` — context‑aware options detection + totals
  - `x987-app/x987/pipeline/steps/catalog.py` — new step (after Ranking) exporting catalog JSON
  - `x987-app/x987/catalog/export.py` — exporter (single source of truth for FE/docs)
  - `x987-app/x987/config/validation.py` — validates `[vehicles]` and `[options_per_generation]`
  - `x987-config/config.toml` — MSRP fallback (ACTIVE_RIDE=7140)
- FE API
  - `GET /api/catalog/generations` — serves generation catalog JSON (or defaults)
  - `x987-web/apps/api/src/index.ts`, `x987-web/apps/api/src/utils/fsPaths.ts`
  - Data: `x987-web/apps/api/data/generation_catalog.json` (normalized codes, ACTIVE_RIDE)
- FE
  - `x987-web/apps/fe/src/App.tsx` — plain‑text generation block (Trims, Options $MSRP); Controls tab dump; normalize FE '982/718' → JSON '982'
  - Table “Options” column shows “(no options detected)” when empty

## How to Verify
1. Run the pipeline; confirm `catalog` step writes:
   - `x987-web/apps/api/data/generation_catalog.json`
   - `x987-data/metadata/generation_catalog.json`
2. FE API:
   - `GET /api/catalog/generations` → `{ ok: true, source: "json" }`
   - `GET /api/ranking/latest` → rows contain `mileage`, `options_list`, `total_options_msrp`
3. FE UI:
   - Results: select 987.2 → “Trims: S, R, Spyder” and options with MSRP
   - Controls: full readable catalog dump, Taycan 9J1 shows ACTIVE_RIDE ($7,140)

## Backward Compatibility
- Generation filtering unchanged; FE keys preserved
- MSRP/options display is additive; no breaking changes to price/ranking

## Follow‑ups (optional)
- Fill per‑gen options for gens still marked `options_default: true` (Cayenne 955/957–9Y0, Panamera 970–971.2, Taycan 9J1, Macan 95B.*, 981/982)
- Option chip shortener for “Active Ride” if desired
- Harden extractors for sources with missing mileage/options

## Screens/Notes
- FE shows explicit “(no options detected)” when options_list is empty
- Remaining “(defaults pending)” reflects gens without per‑gen options in catalog
