### PR TITLE
feat(scraping): enriched-skip + DB transition cleanups

### DIFF
--- a/x987-app/x987/pipeline/backfill_url_vin_db.py
+++ b/x987-app/x987/pipeline/backfill_url_vin_db.py
@@ -1,0 +1,41 @@
+"""
+Backfill URL→VIN index from the SQLite DB.
+
+Scans `listings` and `parsed_listings` to upsert url_vin_index for any
+listing that has a VIN. This helps enriched-shortcut skipping work earlier
+in runs before VINs are seen again.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+def backfill(conn) -> int:
+    """Upsert url_vin_index for rows with VIN, returns count upserted."""
+    try:
+        cur = conn.execute(
+            """
+            SELECT l.listing_key, COALESCE(pl.vin, l.vin) AS vin
+            FROM listings l
+            LEFT JOIN parsed_listings pl ON pl.listing_id = l.id
+            WHERE COALESCE(pl.vin, l.vin) IS NOT NULL AND TRIM(COALESCE(pl.vin, l.vin)) <> ''
+            """
+        )
+        rows = cur.fetchall() or []
+        total = 0
+        for r in rows:
+            url = str(r[0] or '').strip()
+            vin = str(r[1] or '').strip().upper()
+            if not url or not vin:
+                continue
+            try:
+                conn.execute(
+                    "INSERT INTO url_vin_index (canonical_url, vin, updated_at) VALUES (?,?,datetime('now'))\n                     ON CONFLICT(canonical_url) DO UPDATE SET vin=excluded.vin, updated_at=excluded.updated_at",
+                    (url, vin),
+                )
+                total += 1
+            except Exception:
+                continue
+        return total
+    except Exception:
+        return 0
+

--- a/x987-app/x987/pipeline/steps/collection.py
+++ b/x987-app/x987/pipeline/steps/collection.py
@@ -372,7 +372,16 @@ class CollectionStep(BasePipelineStep):
                             try:
                                 mileage = extract_mileage_unified(container_text)
                             except Exception:
-                                pass
+                                mileage = None
+                            # Fallback: simple regex for mileage patterns if extractor misses
+                            if mileage is None:
+                                try:
+                                    import re
+                                    m = re.search(r"([0-9][0-9,]{1,7})\s*(mi\.?|miles)\b", container_text, re.I)
+                                    if m:
+                                        mileage = int(str(m.group(1)).replace(',', ''))
+                                except Exception:
+                                    mileage = None
                             try:
                                 y, m, _t = extract_vehicle_info_unified(title or container_text)
                                 year, model = y, m

--- a/x987-app/x987/pipeline/steps/runner.py
+++ b/x987-app/x987/pipeline/steps/runner.py
@@ -77,7 +77,15 @@ class PipelineRunner:
                 summary = ""
                 data = step_result.data if isinstance(step_result.data, dict) else {}
                 if step_name == "transformation":
-                    summary = f"processed {data.get('total_listings', 0)}"
+                    # processed T, options O (avg P/listing)
+                    total = data.get('total_listings', 0)
+                    stats = data.get('transformation_stats', {}) if isinstance(data, dict) else {}
+                    opts = stats.get('options_detected', None)
+                    avg = stats.get('average_options_per_listing', None)
+                    if opts is not None and avg is not None:
+                        summary = f"processed {total}, options {opts} (avg {avg:.1f}/listing)"
+                    else:
+                        summary = f"processed {total}"
                 elif step_name == "deduplication":
                     summary = f"retained {data.get('final_count', 0)}/{data.get('original_count', 0)} (removed {data.get('duplicates_removed', 0)})"
                 elif step_name == "fair_value":
@@ -88,14 +96,22 @@ class PipelineRunner:
                 elif step_name == "view":
                     summary = f"displayed {data.get('total_listings', 0)}"
                 elif step_name == "collection":
-                    # Collection step often returns list; runner summary may be limited
+                    # found X URLs (Y new)
                     if isinstance(step_result.data, list):
-                        count = len(step_result.data)
+                        total = len(step_result.data)
+                        new = None
                     else:
-                        count = data.get('urls_collected') if 'urls_collected' in data else (
-                            data.get('total_urls') if 'total_urls' in data else data.get('count')
+                        total = data.get('urls_collected') if 'urls_collected' in data else (
+                            len(data.get('collection_data', []) ) if isinstance(data.get('collection_data'), list) else data.get('total_urls')
                         )
-                    summary = f"found {count} URLs" if count != "" else "completed"
+                        cs = data.get('collection_stats') if isinstance(data, dict) else {}
+                        new = (cs or {}).get('new_count') if isinstance(cs, dict) else None
+                    if total is None:
+                        summary = "completed"
+                    else:
+                        summary = f"found {total} URLs"
+                        if new is not None:
+                            summary += f" ({new} new)"
                 elif step_name == "scraping":
                     # Try to summarize success/fail from data if present (preserve zeros)
                     succ = data.get('successful_scrapes') if 'successful_scrapes' in data else (
@@ -107,10 +123,21 @@ class PipelineRunner:
                     total = data.get('total_pages_scraped') if 'total_pages_scraped' in data else (
                         data.get('total') if 'total' in data else data.get('total_listings')
                     )
+                    enr = data.get('enriched_shortcuts') if isinstance(data, dict) else None
+                    cache_hits = data.get('cache_hits') if isinstance(data, dict) else None
                     if succ is not None or fail is not None:
                         summary = f"scraped {succ or 0} ok, {fail or 0} failed"
+                        extras = []
+                        if enr is not None:
+                            extras.append(f"{enr} enriched skips")
+                        if cache_hits is not None:
+                            extras.append(f"{cache_hits} cache hits")
+                        if extras:
+                            summary += ", " + ", ".join(extras)
                     elif total is not None:
                         summary = f"scraped {total}"
+                        if enr is not None:
+                            summary += f" ({enr} enriched skips)"
                     else:
                         summary = "completed"
                 else:

--- a/x987-app/x987/pipeline/steps/scraping.py
+++ b/x987-app/x987/pipeline/steps/scraping.py
@@ -63,6 +63,17 @@ class ScrapingStep(BasePipelineStep):
                 clean_text_unified = None  # type: ignore
             try:
                 blob = rec.get('data_blob') or {}
+                # If cache contains enriched-only payload with year, accept as complete
+                if isinstance(blob, dict) and blob.get('enriched'):
+                    try:
+                        parsed = (blob['enriched'].get('parsed') or blob['enriched'].get('parsed_json') or {}) if isinstance(blob['enriched'], dict) else {}
+                        if parsed.get('year') is not None:
+                            # Proceed to TTL check below
+                            pass
+                        else:
+                            return False, "miss:incomplete_enriched", rec
+                    except Exception:
+                        return False, "miss:incomplete_enriched", rec
                 raw_text = ""
                 if isinstance(blob, dict):
                     dom = blob.get("raw_dom_text") or ""
@@ -75,7 +86,8 @@ class ScrapingStep(BasePipelineStep):
                 has_miles = extract_mileage_unified(raw_text) is not None if extract_mileage_unified else True
                 y_m_t = extract_vehicle_info_unified(raw_text) if extract_vehicle_info_unified else (None, None, None)
                 year_val = y_m_t[0] if isinstance(y_m_t, tuple) and len(y_m_t) >= 1 else None
-                if not (has_price and has_miles and year_val is not None):
+                # If we don’t have enriched fallback, require price/miles/year from raw_text
+                if not (isinstance(blob, dict) and blob.get('enriched')) and not (has_price and has_miles and year_val is not None):
                     return False, "miss:incomplete_fields", rec
             except Exception:
                 pass
@@ -291,6 +303,14 @@ class ScrapingStep(BasePipelineStep):
                     try:
                         db_ensure_db(config)
                         db_conn = db_get_connection(config)
+                        # One-time DB backfill of URL→VIN index before processing batch
+                        try:
+                            from ..backfill_url_vin_db import backfill as _backfill_db
+                            count = _backfill_db(db_conn)
+                            if count:
+                                print(f"     🔧 Backfilled URL→VIN from DB: {count}")
+                        except Exception:
+                            pass
                     except Exception:
                         db_conn = None
 
@@ -325,6 +345,15 @@ class ScrapingStep(BasePipelineStep):
                         if not listing_url:
                             print(f"        ⚠️  Skipping URL {i+1}: No listing URL found")
                             continue
+                        # Skip unsupported sources (placeholder until implemented)
+                        try:
+                            from urllib.parse import urlsplit as _split
+                            host = (_split(listing_url).netloc or '').lower()
+                            if 'hemmings.com' in host or 'carvana.com' in host:
+                                print(f"        ⏭️  Skipping unsupported source: {host}")
+                                continue
+                        except Exception:
+                            pass
                         
                         print(f"        🕷️  Scraping {i+1}/{len(prepared_urls)}: {self._get_short_url(listing_url)}")
                         
@@ -347,7 +376,9 @@ class ScrapingStep(BasePipelineStep):
                                     enr = None
                             if enr is None and vin:
                                 enr = vin_store.get(vin) if isinstance(vin_store, dict) else None
-                            if enr:
+                            # Require mileage present from collection to safely skip; else fetch VDP to populate
+                            has_miles = url_data.get('mileage') is not None
+                            if enr and has_miles:
                                 # Produce a synthetic result using enriched data and current search price/mileage
                                 enriched_payload = {
                                     'vin': vin,
@@ -377,6 +408,15 @@ class ScrapingStep(BasePipelineStep):
                                 scraped_data.append(scraped_result)
                                 successful_count += 1
                                 print(f"        🚫 Skipped VDP (enriched VIN {vin})")
+                                # Save minimal cache entry for TTL-based skipping later
+                                try:
+                                    if db_conn is not None:
+                                        db_cache_save(db_conn, canonical, {'enriched': enriched_payload})
+                                    else:
+                                        listing_cache.save_result(canonical, {'enriched': enriched_payload})
+                                        listing_cache.save()
+                                except Exception:
+                                    pass
                                 continue
                         if cache_enabled:
                             skip = False
@@ -611,6 +651,14 @@ class ScrapingStep(BasePipelineStep):
                     if _is_sqlite_enabled(cfg):
                         _ensure_db(cfg)
                         db_conn = _get_connection(cfg)
+                        # One-time DB backfill of URL→VIN index before workers
+                        try:
+                            from ..backfill_url_vin_db import backfill as _backfill_db
+                            count = _backfill_db(db_conn)
+                            if count:
+                                print(f"     🔧 Backfilled URL→VIN from DB: {count}")
+                        except Exception:
+                            pass
                 except Exception:
                     db_conn = None
 
@@ -663,6 +711,14 @@ class ScrapingStep(BasePipelineStep):
                             if not listing_url:
                                 failed_count += 1
                                 return
+                            # Skip unsupported sources (placeholder)
+                            try:
+                                from urllib.parse import urlsplit as _split
+                                host = (_split(listing_url).netloc or '').lower()
+                                if 'hemmings.com' in host or 'carvana.com' in host:
+                                    return
+                            except Exception:
+                                pass
                             # Enriched-shortcut or cache decision before creating page
                             canonical = url_data.get('canonical_url') or canonicalize_url(listing_url)
                             if skip_if_enriched and canonical in url_vin_map:
@@ -683,7 +739,8 @@ class ScrapingStep(BasePipelineStep):
                                         enr = None
                                 if enr is None and vin:
                                     enr = vin_store.get(vin) if isinstance(vin_store, dict) else None
-                                if enr:
+                                has_miles = url_data.get('mileage') is not None
+                                if enr and has_miles:
                                     results.append({
                                         'scraping_id': url_data.get('scraping_id'),
                                         'source_url': url_data.get('source_url', ''),
@@ -709,6 +766,16 @@ class ScrapingStep(BasePipelineStep):
                                         }}
                                     })
                                     successful_count += 1
+                                    # Save minimal cache entry for TTL-based skipping later
+                                    try:
+                                        if db_conn is not None:
+                                            from ...db.api import cache_save as _db_cache_save
+                                            _db_cache_save(db_conn, canonical, {'enriched': enr})
+                                        else:
+                                            listing_cache.save_result(canonical, {'enriched': enr})
+                                            listing_cache.save()
+                                    except Exception:
+                                        pass
                                     return
                             if cache_enabled:
                                 # Prefer DB cache TTL, fallback to JSON cache
@@ -1048,9 +1115,10 @@ class ScrapingStep(BasePipelineStep):
         avg_validation_score = sum(validation_scores) / len(validation_scores) if validation_scores else 0
         # Cache metrics
         cache_hits = len([d for d in processed_data if d.get('cache_hit') or d.get('scraping_method') == 'cache'])
-        network_requests = len(processed_data) - cache_hits
         # Enriched shortcut metrics
         enriched_shortcuts = len([d for d in processed_data if str(d.get('scraping_method', '')).lower() == 'enriched_shortcut'])
+        # Network requests exclude cache and enriched shortcuts
+        network_requests = len(processed_data) - cache_hits - enriched_shortcuts
         try:
             print(f"🧠 Cache hits: {cache_hits} | Network scrapes: {network_requests} | Enriched skips: {enriched_shortcuts}")
         except Exception:

--- a/x987-app/x987/pipeline/steps/scraping.py
+++ b/x987-app/x987/pipeline/steps/scraping.py
@@ -148,6 +148,8 @@ class ScrapingStep(BasePipelineStep):
                 # Step 2: Scrape data
                 print("🕷️  Step 2: Scraping data from URLs...")
                 kwargs_without_headful = {k: v for k, v in kwargs.items() if k != 'headful'}
+                # Pass config through so concurrent path can use DB cache/enrichment
+                kwargs_without_headful['config'] = config
                 if max(1, int(scraping_config.get('concurrency', 1))) > 1:
                     scraped_data = self._scrape_urls_concurrent(prepared_urls, scraping_config, headful, **kwargs_without_headful)
                 else:
@@ -303,12 +305,16 @@ class ScrapingStep(BasePipelineStep):
                     except Exception:
                         url_vin_map = {}
                     try:
-                        vin_path = Path('x987-data/metadata/vin_enriched.json')
-                        if vin_path.exists():
-                            raw = json.loads(vin_path.read_text(encoding='utf-8'))
-                            vin_store = raw.get('entries') if isinstance(raw, dict) and 'entries' in raw else raw
-                            if not isinstance(vin_store, dict):
-                                vin_store = {}
+                        # Prefer DB-backed VIN enrichment; fall back to JSON file
+                        if db_conn is not None:
+                            vin_store = {}
+                        else:
+                            vin_path = Path('x987-data/metadata/vin_enriched.json')
+                            if vin_path.exists():
+                                raw = json.loads(vin_path.read_text(encoding='utf-8'))
+                                vin_store = raw.get('entries') if isinstance(raw, dict) and 'entries' in raw else raw
+                                if not isinstance(vin_store, dict):
+                                    vin_store = {}
                     except Exception:
                         vin_store = {}
 
@@ -326,13 +332,27 @@ class ScrapingStep(BasePipelineStep):
                         canonical = url_data.get('canonical_url') or canonicalize_url(listing_url)
                         if skip_if_enriched and canonical in url_vin_map:
                             vin = str(url_vin_map.get(canonical) or '').strip().upper()
-                            enr = vin_store.get(vin) if vin else None
+                            enr = None
+                            if vin and db_conn is not None:
+                                try:
+                                    row = db_conn.execute(
+                                        "SELECT parsed_json, derived_json FROM vin_enriched WHERE vin = ?",
+                                        (vin,),
+                                    ).fetchone()
+                                    if row:
+                                        parsed_json = json.loads(row[0]) if row[0] else {}
+                                        derived_json = json.loads(row[1]) if row[1] else {}
+                                        enr = {"parsed": parsed_json, "derived": derived_json}
+                                except Exception:
+                                    enr = None
+                            if enr is None and vin:
+                                enr = vin_store.get(vin) if isinstance(vin_store, dict) else None
                             if enr:
                                 # Produce a synthetic result using enriched data and current search price/mileage
                                 enriched_payload = {
                                     'vin': vin,
-                                    'parsed': enr.get('parsed', {}),
-                                    'derived': enr.get('derived', {})
+                                    'parsed': enr.get('parsed', enr.get('parsed_json', {})) if isinstance(enr, dict) else {},
+                                    'derived': enr.get('derived', enr.get('derived_json', {})) if isinstance(enr, dict) else {},
                                 }
                                 scraped_result = {
                                     'scraping_id': url_data.get('scraping_id'),
@@ -587,6 +607,7 @@ class ScrapingStep(BasePipelineStep):
                     except Exception:
                         url_vin_map = {}
                     try:
+                        # In async path we don't share DB conn; rely on JSON fallback for now
                         vin_path = Path('x987-data/metadata/vin_enriched.json')
                         if vin_path.exists():
                             raw = json.loads(vin_path.read_text(encoding='utf-8'))
@@ -628,7 +649,22 @@ class ScrapingStep(BasePipelineStep):
                             canonical = url_data.get('canonical_url') or canonicalize_url(listing_url)
                             if skip_if_enriched and canonical in url_vin_map:
                                 vin = str(url_vin_map.get(canonical) or '').strip().upper()
-                                enr = vin_store.get(vin) if vin else None
+                                # Prefer DB-backed enrichment, fallback to JSON store
+                                enr = None
+                                if vin and db_conn is not None:
+                                    try:
+                                        row = db_conn.execute(
+                                            "SELECT parsed_json, derived_json FROM vin_enriched WHERE vin = ?",
+                                            (vin,),
+                                        ).fetchone()
+                                        if row:
+                                            parsed_json = json.loads(row[0]) if row[0] else {}
+                                            derived_json = json.loads(row[1]) if row[1] else {}
+                                            enr = {"parsed": parsed_json, "derived": derived_json}
+                                    except Exception:
+                                        enr = None
+                                if enr is None and vin:
+                                    enr = vin_store.get(vin) if isinstance(vin_store, dict) else None
                                 if enr:
                                     results.append({
                                         'scraping_id': url_data.get('scraping_id'),
@@ -650,37 +686,49 @@ class ScrapingStep(BasePipelineStep):
                                         'raw_html': '',
                                         'extracted_data': { 'enriched': {
                                             'vin': vin,
-                                            'parsed': enr.get('parsed', {}),
-                                            'derived': enr.get('derived', {})
+                                            'parsed': enr.get('parsed', enr.get('parsed_json', {})) if isinstance(enr, dict) else {},
+                                            'derived': enr.get('derived', enr.get('derived_json', {})) if isinstance(enr, dict) else {}
                                         }}
                                     })
                                     successful_count += 1
                                     return
                             if cache_enabled:
-                                should_skip, reason = listing_cache.should_skip(canonical, ttl_days=ttl_days)
-                                if should_skip:
-                                    rec = listing_cache.get(canonical)
-                                    if rec and rec.data_blob:
-                                        results.append({
-                                            'scraping_id': url_data.get('scraping_id'),
-                                            'source_url': url_data.get('source_url', ''),
-                                            'listing_url': listing_url,
-                                            'canonical_url': canonical,
-                                            'title': url_data.get('title', ''),
-                                            'collection_timestamp': url_data.get('collection_timestamp', ''),
-                                            'scraping_timestamp': datetime.now().isoformat(),
-                                            'scraping_status': 'success',
-                                            'scraping_method': 'cache',
-                                            'is_new': url_data.get('is_new', ''),
-                                            'first_seen_at': url_data.get('first_seen_at', ''),
-                                            'cache_hit': True,
-                                            'cache_reason': reason,
-                                            'raw_text': '',
-                                            'raw_html': '',
-                                            'extracted_data': rec.data_blob,
-                                        })
-                                        successful_count += 1
-                                        return
+                                # Prefer DB cache TTL, fallback to JSON cache
+                                rec_blob = None
+                                reason = ""
+                                if db_conn is not None:
+                                    try:
+                                        should, reason, rec = self._should_skip_db_cache(db_conn, canonical, ttl_days=ttl_days)
+                                        if should and rec:
+                                            rec_blob = rec.get('data_blob')
+                                    except Exception:
+                                        rec_blob = None
+                                else:
+                                    should_skip, reason = listing_cache.should_skip(canonical, ttl_days=ttl_days)
+                                    if should_skip:
+                                        rec = listing_cache.get(canonical)
+                                        rec_blob = rec.data_blob if rec else None
+                                if rec_blob is not None:
+                                    results.append({
+                                        'scraping_id': url_data.get('scraping_id'),
+                                        'source_url': url_data.get('source_url', ''),
+                                        'listing_url': listing_url,
+                                        'canonical_url': canonical,
+                                        'title': url_data.get('title', ''),
+                                        'collection_timestamp': url_data.get('collection_timestamp', ''),
+                                        'scraping_timestamp': datetime.now().isoformat(),
+                                        'scraping_status': 'success',
+                                        'scraping_method': 'cache',
+                                        'is_new': url_data.get('is_new', ''),
+                                        'first_seen_at': url_data.get('first_seen_at', ''),
+                                        'cache_hit': True,
+                                        'cache_reason': reason,
+                                        'raw_text': '',
+                                        'raw_html': '',
+                                        'extracted_data': rec_blob,
+                                    })
+                                    successful_count += 1
+                                    return
 
                             page = await context.new_page()
                             try:
@@ -791,6 +839,12 @@ class ScrapingStep(BasePipelineStep):
 
                     await context.close()
                     await browser.close()
+                    # Close DB connection if used
+                    try:
+                        if db_conn is not None:
+                            db_conn.close()
+                    except Exception:
+                        pass
 
                     print(f"     📊 Concurrent scraping completed: {successful_count} successful, {failed_count} failed")
                     return results
@@ -983,8 +1037,10 @@ class ScrapingStep(BasePipelineStep):
         # Cache metrics
         cache_hits = len([d for d in processed_data if d.get('cache_hit') or d.get('scraping_method') == 'cache'])
         network_requests = len(processed_data) - cache_hits
+        # Enriched shortcut metrics
+        enriched_shortcuts = len([d for d in processed_data if str(d.get('scraping_method', '')).lower() == 'enriched_shortcut'])
         try:
-            print(f"🧠 Cache hits: {cache_hits} | Network scrapes: {network_requests}")
+            print(f"🧠 Cache hits: {cache_hits} | Network scrapes: {network_requests} | Enriched skips: {enriched_shortcuts}")
         except Exception:
             pass
 
@@ -997,12 +1053,16 @@ class ScrapingStep(BasePipelineStep):
             "invalid_data": invalid_data,
             "cache_hits": cache_hits,
             "network_requests": network_requests,
+            "enriched_shortcuts": enriched_shortcuts,
             "saved_files": saved_files,
             "scraping_stats": {
                 "scraping_success_rate": successful_scrapes / total_urls if total_urls > 0 else 0,
                 "data_validation_rate": valid_data / successful_scrapes if successful_scrapes > 0 else 0,
                 "average_validation_score": avg_validation_score,
-                "total_processing_time": sum(d.get('scraping_metadata', {}).get('processing_time_ms', 0) for d in processed_data)
+                "total_processing_time": sum(d.get('scraping_metadata', {}).get('processing_time_ms', 0) for d in processed_data),
+                "cache_hits": cache_hits,
+                "network_requests": network_requests,
+                "enriched_shortcuts": enriched_shortcuts,
             },
             "scraping_timestamp": datetime.now().isoformat()
         }

--- a/x987-app/x987/pipeline/steps/scraping.py
+++ b/x987-app/x987/pipeline/steps/scraping.py
@@ -551,6 +551,12 @@ class ScrapingStep(BasePipelineStep):
                 
                 context.close()
                 browser.close()
+                # Close DB connection (serial path)
+                try:
+                    if db_conn is not None:
+                        db_conn.close()
+                except Exception:
+                    pass
             
             print(f"     📊 Scraping completed: {successful_count} successful, {failed_count} failed")
             return scraped_data
@@ -595,6 +601,18 @@ class ScrapingStep(BasePipelineStep):
                 cache_dir = output_dir.parent if output_dir.name == 'results' else output_dir.parent
                 cache_path = cache_dir / 'listing_cache.json'
                 listing_cache = ListingCache(cache_path)
+
+                # Optional DB connection for cache/enrichment lookups
+                db_conn = None
+                try:
+                    cfg = kwargs.get('config', {})
+                    from ...db.integration import is_sqlite_enabled as _is_sqlite_enabled
+                    from ...db.core import get_connection as _get_connection, ensure_db as _ensure_db
+                    if _is_sqlite_enabled(cfg):
+                        _ensure_db(cfg)
+                        db_conn = _get_connection(cfg)
+                except Exception:
+                    db_conn = None
 
                 # Load URL→VIN index and VIN-enriched store for fast-shortcuts
                 skip_if_enriched = bool(scraping_config.get('skip_vdp_if_enriched', True))
@@ -889,12 +907,6 @@ class ScrapingStep(BasePipelineStep):
             else:
                 data['validation_status'] = 'failed'
                 failed_count += 1
-                # Close DB cache connection if opened
-                try:
-                    if db_conn is not None:
-                        db_conn.close()
-                except Exception:
-                    pass
             processed_data.append(data)
         
         print(f"       ✅ Successfully processed {successful_count} items")

--- a/x987-app/x987/pipeline/steps/transformation.py
+++ b/x987-app/x987/pipeline/steps/transformation.py
@@ -172,6 +172,22 @@ class TransformationStep(BasePipelineStep):
                 except Exception:
                     enriched = {}
 
+                # VIN fallback from enriched payload when not present in raw text
+                try:
+                    if not extracted_data.get('vin') and isinstance(enriched, dict):
+                        ev = enriched.get('vin') or (enriched.get('parsed') or {}).get('vin')
+                        if ev:
+                            extracted_data['vin'] = str(ev).upper()
+                except Exception:
+                    pass
+                # Persist URL→VIN index when obtained from enrichment
+                try:
+                    if extracted_data.get('vin') and listing.get('canonical_url'):
+                        from ..url_vin_index import upsert_url_vin
+                        upsert_url_vin(str(listing.get('canonical_url')), str(extracted_data.get('vin')).upper())
+                except Exception:
+                    pass
+
                 # Extract year
                 year_value = None
                 if enriched and isinstance(enriched.get('parsed'), dict):
@@ -206,14 +222,25 @@ class TransformationStep(BasePipelineStep):
                     extracted_data['price'] = 'Unknown'
                     extracted_data['price_confidence'] = 0.0
                 
-                # Extract mileage
+                # Extract mileage (fallback to collection when DOM text insufficient)
                 mileage_value = extractor.extract_mileage(_raw_text)
                 if mileage_value is not None:
                     extracted_data['mileage'] = f"{mileage_value:,}"
                     extracted_data['mileage_confidence'] = 1.0
                 else:
-                    extracted_data['mileage'] = 'Unknown'
-                    extracted_data['mileage_confidence'] = 0.0
+                    # Fallback: accept numeric or numeric string from collection/scraping
+                    try:
+                        mv = listing.get('mileage')
+                        if mv is not None:
+                            mv_int = int(str(mv).replace(',', '').replace('$', '').strip())
+                            extracted_data['mileage'] = f"{mv_int:,}"
+                            extracted_data['mileage_confidence'] = 0.75
+                        else:
+                            extracted_data['mileage'] = 'Unknown'
+                            extracted_data['mileage_confidence'] = 0.0
+                    except Exception:
+                        extracted_data['mileage'] = 'Unknown'
+                        extracted_data['mileage_confidence'] = 0.0
                 
                 # Extract model/trim as separate fields (prefer enriched if available)
                 model_value = None

--- a/x987-config/config.toml
+++ b/x987-config/config.toml
@@ -13,9 +13,9 @@ db_path = "x987-data/x987.db"
 urls = [
     #"https://www.autotempest.com/results?keywords=black%20edition&localization=country&make=porsche&maxyear=2012&minyear=2009&model=cayman&transmission=auto&zip=30214",
     "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=cayman&transmission=auto&zip=30214",
-    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=boxster&transmission=auto&zip=30214",
-    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2016&minyear=2013&model=cayman&transmission=auto&zip=30214",
-    #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2016&minyear=2013&model=boxster&transmission=auto&zip=30214",
+    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2012&minyear=2009&model=boxster&transmission=auto&zip=30214",
+    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2016&minyear=2013&model=cayman&transmission=auto&zip=30214",
+    "https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2016&minyear=2013&model=boxster&transmission=auto&zip=30214",
     #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2008&minyear=2005&model=boxster&transmission=auto&zip=30214",
     #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2008&minyear=2005&model=cayman&transmission=auto&zip=30214",
     #"https://www.autotempest.com/results?localization=country&make=porsche&maxyear=2004&minyear=1999&model=911&transmission=auto&zip=30214",

--- a/x987-web/apps/fe/src/App.tsx
+++ b/x987-web/apps/fe/src/App.tsx
@@ -80,6 +80,8 @@ export function App() {
   const [maxPrice, setMaxPrice] = useState<number | null>(50000)
   const [sortState, setSortState] = useState<{ key?: string; order?: 'ascend' | 'descend' }>({})
   const [favOnly, setFavOnly] = useState<boolean>(false)
+  // Quick filter: VIN present but not enriched
+  const [vinNoEnrichedOnly, setVinNoEnrichedOnly] = useState<boolean>(false)
 
   // Facets reflect VIN-enriched data and current filters (top + column)
   const optionFacets = useMemo(() => {
@@ -840,8 +842,19 @@ export function App() {
         } catch { return false }
       })
     }
+    // Apply VIN but not enriched filter
+    if (vinNoEnrichedOnly) {
+      rows = rows.filter((r: any) => {
+        try {
+          const vin = String(r?.vin || r?.VIN || '').trim().toUpperCase()
+          if (!vin) return false
+          const enriched = vinMap[vin]
+          return !enriched
+        } catch { return false }
+      })
+    }
     return rows
-  }, [data, generation, body, maxPrice, vinMap, favOnly, favorites])
+  }, [data, generation, body, maxPrice, vinMap, favOnly, favorites, vinNoEnrichedOnly])
   
   const sorted = useMemo(() => {
     const rows = [...filtered]
@@ -1025,6 +1038,9 @@ export function App() {
               </Button>
               <Button type={favOnly ? 'primary' : 'default'} onClick={() => setFavOnly(v => !v)} icon={favOnly ? <StarFilled /> : <StarOutlined />}>
                 Favorites Only
+              </Button>
+              <Button type={vinNoEnrichedOnly ? 'primary' : 'default'} onClick={() => setVinNoEnrichedOnly(v => !v)}>
+                VIN w/o Enrichment
               </Button>
             </div>
 


### PR DESCRIPTION
# Enriched Skip + DB Transition Cleanups

This PR supersedes the earlier DB transition by tightening scrape-skip logic, enriching the collection step, and improving reporting and UX.

Highlights
- Accurate scraping stats: enriched skips, cache hits, and network requests.
- Safer enriched skips: require URL→VIN mapping, VIN enrichment, and collection mileage; otherwise fetch VDP to keep data complete.
- DB backfill: populate URL→VIN index from existing DB rows before scraping for better early skips.
- Collection: better mileage extraction (fallback regex on AutoTempest results).
- Cache: when enriched-skip occurs, write a minimal cache payload to support TTL skips on subsequent runs.
- Unsupported sources: temporarily skip Hemmings and Carvana.
- Transformation: fill VIN from enriched payload, use collection mileage fallback, and persist URL→VIN from enrichment.
- Runner output: concise, trustworthy one-line summaries per step.
- Frontend: quick filter button for “VIN w/o Enrichment.”

Risk
- Low. Single-user, reversible; scraping does more (not less) when data is incomplete.

Validation
- Pipeline run now shows increased enriched skips where appropriate, miles preserved for the rest, and correct stats.

Supersedes
- #12 (SQLite-backed data layer). This PR includes all those changes plus the skip optimizations.
